### PR TITLE
Add Skip Button

### DIFF
--- a/src/workout/routines/ankle.cljc
+++ b/src/workout/routines/ankle.cljc
@@ -10,7 +10,6 @@
     :filename "heel-cord-stretch.png"}
 
    {:name "Knee Swing"
-    :two-sided? true
     :filename "knee-swing.png"}
    
    {:name "Calf Stretch"
@@ -45,7 +44,8 @@
     :two-sided? true
     :filename "towel-scrunch.png"}
    
-   {:name "Single Leg balance"}
+   {:name "Single Leg balance"
+    :two-sided? true}
 
    {:name "One-legged calf raise"
     :two-sided? true}


### PR DESCRIPTION
# Summary
Added ability to skip an exercise. 

This means the schedule is now stateful; I added two atoms to 1) maintain a copy of the current schedule and 2) maintain an index for how far into the schedule we are. (I mean, `process-schedule` already has a `!` beside its name; adding more state is not that bad, right?)

# Design Decisions
I considered adding just one atom to include a dictionary of both, but two atoms seemed easier from a programmatic point of view instead of constantly having to get the index out of a dictionary. I also considered just keeping the "remaining schedule" in an atom but again, "increment this index" seemed logically easier than "pop the front of schedule"

Another design decision I made was not resetting the atoms at any point (i.e. at `force-stop!`). Seemed _functionally_ unnecessary (plus we can use the state in the future for fun things like an exercise summary!), but I can see how it may be kinda weird _spiritually_?

# Future Improvements
One caveat is that if you skip an exercise before the halfway point, you only skip to the halfway message instead of the next exercise. I think it's fine for now to hit skip twice, we'll see how annoying this UX is and prioritize the changes accordingly. We can keep issue #5 open until we have the logic to properly skip. 

# Disclosure
Copilot wrote most of `process-schedule!`, but I'd say it looks pretty good... I'm 97% sure it works properly xd I did manually test it, the app seems to be behaving as expected
